### PR TITLE
Make Drive readOnly

### DIFF
--- a/DokanPbo.Core/PboFS.cs
+++ b/DokanPbo.Core/PboFS.cs
@@ -159,7 +159,7 @@ namespace DokanPbo
         public NtStatus GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features, out string fileSystemName, out uint maximumComponentLength, DokanFileInfo info)
         {
             volumeLabel = "PboFS";
-            features = FileSystemFeatures.None;
+            features = FileSystemFeatures.ReadOnlyVolume;
             fileSystemName = String.Empty;
             maximumComponentLength = 256;
             return DokanResult.Success;


### PR DESCRIPTION
Made the drive readonly because windows constantly throws "no space left on device" warnings. And you cannot write to it anyway so this makes more sense.

Also contains a probably minor performance improvement for file lookups