### PR TITLE
New storage for fileTree

### DIFF
--- a/DokanPbo.Core/DokanPbo.Core.csproj
+++ b/DokanPbo.Core/DokanPbo.Core.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DokanPbo.Core</RootNamespace>
     <AssemblyName>DokanPbo.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/DokanPbo.Core/packages.config
+++ b/DokanPbo.Core/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DokanNet" version="1.1.1.1" targetFramework="net452" />
-  <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" />
+  <package id="DokanNet" version="1.1.1.1" targetFramework="net452" requireReinstallation="true" />
+  <package id="StringInterpolationBridgeStrong" version="0.9.1" targetFramework="net452" requireReinstallation="true" />
 </packages>

--- a/DokanPbo/App.config
+++ b/DokanPbo/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/DokanPbo/DokanPbo.csproj
+++ b/DokanPbo/DokanPbo.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DokanPbo</RootNamespace>
     <AssemblyName>DokanPbo</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>

--- a/DokanPbo/Program.cs
+++ b/DokanPbo/Program.cs
@@ -130,7 +130,7 @@ namespace DokanPbo
 #else
                     ILogger logger = new NullLogger();
 #endif
-                    pboFS.Mount(options.MountDirectory, Program.MOUNT_OPTIONS,8, logger);
+                    pboFS.Mount(options.MountDirectory, Program.MOUNT_OPTIONS,1, logger);
                     Console.WriteLine("Success");
                 }
                 catch (DokanException ex)


### PR DESCRIPTION
```
Unordered map (buckets. key is path)
    Lookup is pathhash + vector lookup. Almost constant. O(1)
    Insert might need to rehash. That's cheap.
    Storage requires whole path for each file. 90% redundant data.

Map (binary tree. key is path)
    Lookup needs to walk whole tree. O(log fileCount)
    Inserts equal to lookup
    Storage requires whole path for each file. 90% redundant data.

Trie (custom implemented tree with each path element as node)
    Lookup needs to walk whole tree. More expensive the deeper the path is. O(pathDepth)
    Inserts equal to lookup
    Storage requires each path element's name once.

Ordered vector (key is filepath)
    Lookup binary search. O(log fileCount)
    Insert is O(log fileCount)+moving entries after the insert place to make space
    Storage requires whole path for each file. 90% redundant data.
    
    
Additional Idea. HashSet (Unordered Map, without value. key is pointer to file)
    Pointer to file is unique. file has pointer to parent so you can walk up the whole path.
    GetHashCode() function generates path by walking to parent and taking the names of the nodes.
    Lookup needs to generate hash for file to be found by splitting the path string by delimiter.
    Insert is equal to lookup
    Storage requirement is one reference for each file. Might additionally want to cache the hash inside the file to make GetHashCode() faster.
    https://stackoverflow.com/a/8952026 says it internally stores the hashcode. So we don't have to cache it.
```

Wrote this. And implemented the last one